### PR TITLE
feat(docker): Kura containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # Eclipse Kura™ metapackage
-This project allows to create full featured Eclipse Kura installer in Debian format.
+
+This project provides a Debian package to conveniently install the fully-featured Eclipse Kura™ on Debian-based systems. 
 
 The following architectures are supported:
 
 - arm64
 - amd64
 
+## Docker
+
+A Docker image is available on Docker Hub: https://hub.docker.com/r/eclipsekura/kura
+
+Additional information about the Docker image can be found in the [Dockerfile](docker/Dockerfile.debian) and related [documentation](docker/README.md).

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -54,9 +54,11 @@ COPY ./log4j.xml /opt/eclipse/kura/log4j/log4j.xml
 
 EXPOSE 443
 LABEL org.opencontainers.image.vendor="Eclipse Kura"
-LABEL org.opencontainers.image.authors="Eclipse Kura"
+LABEL org.opencontainers.image.authors="Eclipse Kura (kura-dev@eclipse.org)"
+LABEL org.opencontainers.image.source="https://github.com/eclipse-kura/kura-metapackage"
 LABEL org.opencontainers.image.description="Eclipse Kura Core Docker image for Debian Bullseye"
 LABEL org.opencontainers.image.documentation="https://hub.docker.com/r/eclipse/kura"
+LABEL org.opencontainers.image.url="https://eclipse-kura.github.io/kura/latest/"
 LABEL org.opencontainers.image.title="Eclipse Kura Core Docker Debian Image"
 
 ENTRYPOINT ["/opt/eclipse/kura/bin/start_kura.sh"]
@@ -75,9 +77,11 @@ RUN --mount=type=bind,from=builder,source=/workdir,target=/tmp/packages \
 
 EXPOSE 443
 LABEL org.opencontainers.image.vendor="Eclipse Kura"
-LABEL org.opencontainers.image.authors="Eclipse Kura"
+LABEL org.opencontainers.image.authors="Eclipse Kura (kura-dev@eclipse.org)"
+LABEL org.opencontainers.image.source="https://github.com/eclipse-kura/kura-metapackage"
 LABEL org.opencontainers.image.description="Eclipse Kura Docker image for Debian Bullseye"
 LABEL org.opencontainers.image.documentation="https://hub.docker.com/r/eclipse/kura"
+LABEL org.opencontainers.image.url="https://eclipse-kura.github.io/kura/latest/"
 LABEL org.opencontainers.image.title="Eclipse Kura Docker Debian Image"
 
 ENTRYPOINT ["/opt/eclipse/kura/bin/start_kura.sh"]

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -31,7 +31,6 @@ WORKDIR /workdir
 RUN apt update && apt download \
     kura-core \
     kura-artemis \
-    kura-bluetooth \
     kura-command \
     kura-management-ui \
     kura-position \

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -16,10 +16,9 @@ RUN apt update && \
 SHELL ["/bin/bash", "-c"]
 
 RUN if [ "$RELEASE_BUILD" -eq 1 ]; then \
-        NEXUS_REPO="kura-6"; \
-    else \
-        # FIXME: Not final repository \
         NEXUS_REPO="kura-apt"; \
+    else \
+        NEXUS_REPO="kura-apt-dev"; \
     fi && \
     echo "deb https://repo3.eclipse.org/repository/${NEXUS_REPO}/ bionic main" | tee /etc/apt/sources.list.d/kura.list
 

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -18,6 +18,7 @@ SHELL ["/bin/bash", "-c"]
 RUN if [ "$RELEASE_BUILD" -eq 1 ]; then \
         NEXUS_REPO="kura-6"; \
     else \
+        # FIXME: Not final repository \
         NEXUS_REPO="kura-apt"; \
     fi && \
     echo "deb https://repo3.eclipse.org/repository/${NEXUS_REPO}/ bionic main" | tee /etc/apt/sources.list.d/kura.list
@@ -28,6 +29,7 @@ WORKDIR /workdir
 
 RUN apt update && apt download \
     kura-core \
+    # FIXME: Add missing packages \
     kura-management-ui
 
 # ======================================================================

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -1,7 +1,7 @@
 # ======================================================================
 # Builder image
 # ======================================================================
-FROM debian:bullseye-slim AS builder
+FROM debian:trixie-slim AS builder
 
 ARG RELEASE_BUILD=0
 
@@ -36,7 +36,7 @@ RUN apt update && apt download \
 # ======================================================================
 # Core runtime image
 # ======================================================================
-FROM debian:bullseye-slim AS core-runtime
+FROM debian:trixie-slim AS core-runtime
 
 RUN --mount=type=bind,from=builder,source=/workdir,target=/tmp/packages \
     apt update && \
@@ -57,7 +57,7 @@ EXPOSE 443
 LABEL org.opencontainers.image.vendor="Eclipse Kura"
 LABEL org.opencontainers.image.authors="Eclipse Kura (kura-dev@eclipse.org)"
 LABEL org.opencontainers.image.source="https://github.com/eclipse-kura/kura-metapackage"
-LABEL org.opencontainers.image.description="Eclipse Kura Core Docker image for Debian Bullseye"
+LABEL org.opencontainers.image.description="Eclipse Kura Core Docker image for Debian Trixie"
 LABEL org.opencontainers.image.documentation="https://hub.docker.com/r/eclipse/kura"
 LABEL org.opencontainers.image.url="https://eclipse-kura.github.io/kura/latest/"
 LABEL org.opencontainers.image.title="Eclipse Kura Core Docker Debian Image"
@@ -80,7 +80,7 @@ EXPOSE 443
 LABEL org.opencontainers.image.vendor="Eclipse Kura"
 LABEL org.opencontainers.image.authors="Eclipse Kura (kura-dev@eclipse.org)"
 LABEL org.opencontainers.image.source="https://github.com/eclipse-kura/kura-metapackage"
-LABEL org.opencontainers.image.description="Eclipse Kura Docker image for Debian Bullseye"
+LABEL org.opencontainers.image.description="Eclipse Kura Docker image for Debian Trixie"
 LABEL org.opencontainers.image.documentation="https://hub.docker.com/r/eclipse/kura"
 LABEL org.opencontainers.image.url="https://eclipse-kura.github.io/kura/latest/"
 LABEL org.opencontainers.image.title="Eclipse Kura Docker Debian Image"

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -1,0 +1,81 @@
+# ======================================================================
+# Builder image
+# ======================================================================
+FROM debian:bullseye-slim AS builder
+
+ARG RELEASE_BUILD=0
+
+RUN apt update && \
+    apt install -y \
+    jq \
+    curl \
+    wget \
+    gpg \
+    equivs
+
+SHELL ["/bin/bash", "-c"]
+
+RUN if [ "$RELEASE_BUILD" -eq 1 ]; then \
+        NEXUS_REPO="kura-6"; \
+    else \
+        NEXUS_REPO="kura-apt"; \
+    fi && \
+    echo "deb https://repo3.eclipse.org/repository/${NEXUS_REPO}/ bionic main" | tee /etc/apt/sources.list.d/kura.list
+
+RUN curl -L "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xba7e3df5edc3fc36" | gpg --dearmor | tee /etc/apt/trusted.gpg.d/kura.gpg > /dev/null
+
+WORKDIR /workdir
+
+RUN apt update && apt download \
+    kura-core \
+    kura-management-ui
+
+# ======================================================================
+# Core runtime image
+# ======================================================================
+FROM debian:bullseye-slim AS core-runtime
+
+RUN --mount=type=bind,from=builder,source=/workdir,target=/tmp/packages \
+    apt update && \
+    apt install wget -y && \
+# Install Kura packages \
+    apt install --no-install-recommends -y /tmp/packages/kura-core_*.deb && \
+# Remove ClockService \
+    rm /opt/eclipse/kura/plugins/4/org.eclipse.kura.linux.clock*.jar && \
+# Remove Container Orchestration Service \
+    rm /opt/eclipse/kura/plugins/4s/org.eclipse.kura.container.orchestration.provider*.jar && \
+    rm /opt/eclipse/kura/plugins/4s/org.eclipse.kura.container.provider*.jar && \
+# Clean up \
+    rm -rf /var/lib/apt/lists/*
+
+COPY ./log4j.xml /opt/eclipse/kura/log4j/log4j.xml
+
+EXPOSE 443
+LABEL org.opencontainers.image.vendor="Eclipse Kura"
+LABEL org.opencontainers.image.authors="Eclipse Kura"
+LABEL org.opencontainers.image.description="Eclipse Kura Core Docker image for Debian Bullseye"
+LABEL org.opencontainers.image.documentation="https://hub.docker.com/r/eclipse/kura"
+LABEL org.opencontainers.image.title="Eclipse Kura Core Docker Debian Image"
+
+ENTRYPOINT ["/opt/eclipse/kura/bin/start_kura.sh"]
+
+# ======================================================================
+# Runtime image
+# ======================================================================
+FROM core-runtime AS runtime
+
+RUN --mount=type=bind,from=builder,source=/workdir,target=/tmp/packages \
+# Install Kura packages \
+    apt update && \
+    find /tmp/packages -name "*.deb" -print0 | xargs -0 apt install --no-install-recommends -y && \
+# Clean up \
+    rm -rf /var/lib/apt/lists/*
+
+EXPOSE 443
+LABEL org.opencontainers.image.vendor="Eclipse Kura"
+LABEL org.opencontainers.image.authors="Eclipse Kura"
+LABEL org.opencontainers.image.description="Eclipse Kura Docker image for Debian Bullseye"
+LABEL org.opencontainers.image.documentation="https://hub.docker.com/r/eclipse/kura"
+LABEL org.opencontainers.image.title="Eclipse Kura Docker Debian Image"
+
+ENTRYPOINT ["/opt/eclipse/kura/bin/start_kura.sh"]

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -17,10 +17,12 @@ SHELL ["/bin/bash", "-c"]
 
 RUN if [ "$RELEASE_BUILD" -eq 1 ]; then \
         NEXUS_REPO="kura-apt"; \
+        NEXUS_DISTR="stable"; \
     else \
         NEXUS_REPO="kura-apt-dev"; \
+        NEXUS_DISTR="unstable"; \
     fi && \
-    echo "deb https://repo3.eclipse.org/repository/${NEXUS_REPO}/ bionic main" | tee /etc/apt/sources.list.d/kura.list
+    echo "deb https://repo3.eclipse.org/repository/${NEXUS_REPO}/ ${NEXUS_DISTR} main" | tee /etc/apt/sources.list.d/kura.list
 
 RUN curl -L "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xba7e3df5edc3fc36" | gpg --dearmor | tee /etc/apt/trusted.gpg.d/kura.gpg > /dev/null
 

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -33,6 +33,7 @@ RUN apt update && apt download \
     kura-artemis \
     kura-command \
     kura-management-ui \
+    kura-opcua \
     kura-position \
     kura-wires
 

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -30,8 +30,12 @@ WORKDIR /workdir
 
 RUN apt update && apt download \
     kura-core \
-    # FIXME: Add missing packages \
-    kura-management-ui
+    kura-artemis \
+    kura-bluetooth \
+    kura-command \
+    kura-management-ui \
+    kura-position \
+    kura-wires
 
 # ======================================================================
 # Core runtime image

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,88 @@
+# Kura Container build
+
+The Kura container is a Docker image that provides a runtime environment for Kura. This document describes how to build the Kura container and run it. Kura containers come in two flavors:
+- a core container that contains only the `kura-core` package.
+- a full container that includes a full Kura installation
+
+## Build the core container
+
+Replace `<platform>` with the desired platform (`linux/amd64` or `linux/arm64`), and run the following command:
+
+```bash
+docker build \
+    -f Dockerfile.debian \
+    --platform <platform> \
+    --target core-runtime \
+    -t kura-core .
+```
+
+Supported platforms:
+- `linux/amd64`
+- `linux/arm64`
+
+## Build the full container
+
+Replace `<platform>` with the desired platform (`linux/amd64` or `linux/arm64`), and run the following command:
+
+```bash
+docker build \
+    -f Dockerfile.<image> \
+    --platform <platform> \
+    -t kura .
+```
+
+Supported platforms:
+- `linux/amd64`
+- `linux/arm64`
+
+## Build arguments
+
+- `RELEASE_BUILD`(optional):
+    - If set to `1`, the build will use the latest available **release** version of the artifacts (i.e. it will look for the latest packages in the `kura-deb` repository and in the `kura-release` Maven repository).
+    - If not set, the build will use the latest available **snapshot** version of the artifacts (i.e. it will look for the latest packages in the `kura-develop-deb`/`kura-develop-rpm` repositories and in the `kura-snapshot` Maven repository).
+- `CONTAINER_SECURITY_MANAGER_VERSION`(optional):
+    - If set, the build will look for the specified version of the Container Security Manager artifacts.
+    - If not set, the build will use the latest available version.
+
+## Run the container
+
+Replace `<master_password>` with a unique 32 characters password.
+
+```
+docker run -p 443:443 -it kura
+```
+
+## Container customisation
+
+The Kura container can be customised by creating a new Dockerfile that extends the base Kura container image. We recommend using the **core** image as a base for your customisations but the same approach can be applied to the **full** image. Here is an example of how to create a custom Dockerfile.
+
+In a new directory (`workdir` in this example), we have a couple of packages that we want to install in the Kura container.
+
+```bash
+ls workdir/
+kura-my-package.deb
+kura-my-other-package.deb
+```
+
+Let's say we built the Kura core container image as described above and tagged it as `kura-core`. Now we can create a new Dockerfile in the same directory as the `workdir` directory with the following content:
+
+```Dockerfile
+FROM kura-core
+
+# Bind mount the host workdir directory to /tmp/packages in the container
+RUN --mount=type=bind,source=/workdir,target=/tmp/packages \
+# Install Kura packages \
+    apt update && \
+    find /tmp/packages -name "*.deb" -print0 | xargs -0 apt install --no-install-recommends -y && \
+# Clean up \
+    rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["/opt/eclipse/kura/bin/start_kura.sh"]
+```
+
+Now we can build the custom container image by running the following command in the same directory as the Dockerfile:
+
+```bash
+docker build \
+    -t kura-custom .
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -40,13 +40,8 @@ Supported platforms:
 - `RELEASE_BUILD`(optional):
     - If set to `1`, the build will use the latest available **release** version of the artifacts (i.e. it will look for the latest packages in the `kura-deb` repository and in the `kura-release` Maven repository).
     - If not set, the build will use the latest available **snapshot** version of the artifacts (i.e. it will look for the latest packages in the `kura-develop-deb`/`kura-develop-rpm` repositories and in the `kura-snapshot` Maven repository).
-- `CONTAINER_SECURITY_MANAGER_VERSION`(optional):
-    - If set, the build will look for the specified version of the Container Security Manager artifacts.
-    - If not set, the build will use the latest available version.
 
 ## Run the container
-
-Replace `<master_password>` with a unique 32 characters password.
 
 ```
 docker run -p 443:443 -it kura

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,7 +26,7 @@ Replace `<platform>` with the desired platform (`linux/amd64` or `linux/arm64`),
 
 ```bash
 docker build \
-    -f Dockerfile.<image> \
+    -f Dockerfile.debian \
     --platform <platform> \
     -t kura .
 ```

--- a/docker/log4j.xml
+++ b/docker/log4j.xml
@@ -27,7 +27,7 @@
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
         </Console>
-        <RollingFile name="RollingFile" fileName="${log_dir}/${log_name}.log" filePattern="${log_dir}/${log_name}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        <RollingFile name="RollingFile" fileName="${log_dir}/${log_name}.log" filePattern="${log_dir}/${log_name}-%i.log.gz">
             <PatternLayout>
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
@@ -36,7 +36,7 @@
             </Policies>
             <DefaultRolloverStrategy max="10"/>
         </RollingFile>
-        <RollingFile name="audit" fileName="${log_dir}/${log_name}-audit.log" filePattern="${log_dir}/${log_name}-audit-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        <RollingFile name="audit" fileName="${log_dir}/${log_name}-audit.log" filePattern="${log_dir}/${log_name}-audit-%i.log.gz">
             <RFC5424Layout enterpriseNumber="28392" includeMDC="true" mdcId="RequestContext" appName="EclipseKura" mdcPrefix="" newLine="true">
                 <LoggerFields>
                     <KeyValuePair key="thread" value="%t"/>

--- a/docker/log4j.xml
+++ b/docker/log4j.xml
@@ -68,6 +68,6 @@
             <AppenderRef ref="Console"/>
             <AppenderRef ref="RollingFile"/>
         </Root>
-  </Loggers>
+    </Loggers>
 
 </Configuration>

--- a/docker/log4j.xml
+++ b/docker/log4j.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+     Eurotech
+
+-->
+<Configuration status="warn" strict="true" name="KuraConfig" monitorInterval="30">
+
+    <Properties>
+        <Property name="log_dir">/var/log</Property>
+        <Property name="log_name">kura</Property>
+    </Properties>
+    <Filter type="ThresholdFilter" level="trace"/>
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT" follow="true">
+            <PatternLayout>
+                <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
+            </PatternLayout>
+        </Console>
+        <RollingFile name="RollingFile" fileName="${log_dir}/${log_name}.log" filePattern="${log_dir}/${log_name}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+            <PatternLayout>
+                <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="20 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+        <RollingFile name="audit" fileName="${log_dir}/${log_name}-audit.log" filePattern="${log_dir}/${log_name}-audit-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+            <RFC5424Layout enterpriseNumber="28392" includeMDC="true" mdcId="RequestContext" appName="EclipseKura" mdcPrefix="" newLine="true">
+                <LoggerFields>
+                    <KeyValuePair key="thread" value="%t"/>
+                    <KeyValuePair key="priority" value="%p"/>
+                    <KeyValuePair key="category" value="%c"/>
+                    <KeyValuePair key="exception" value="%ex"/>
+                </LoggerFields>
+            </RFC5424Layout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="20 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.eclipse" level="info" additivity="false">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="RollingFile"/>
+        </Logger>
+        <Logger name="org.glassfish.jersey.internal" level="error" additivity="false">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="RollingFile"/>
+        </Logger>
+        <Logger name="AuditLogger" level="trace" additivity="false">
+            <AppenderRef ref="audit"/>
+        </Logger>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="RollingFile"/>
+        </Root>
+  </Loggers>
+
+</Configuration>


### PR DESCRIPTION
This PR introduces the Dockerfile and related documentation to build the Kura container. The docker image is based off Debian Trixie.

Image size fall between the two old images:

| Repository | Tag | Size |
|------------|-----|------|
| kura | latest | 531MB |
| kura | latest-core | 445MB |
| eclipse/kura | 5.6.0-alpine-x86_64 | 417MB |
| eclipse/kura | 5.6.0-ubi8-x86_64 | 651MB |


---

Tested using the x86_64 image, working as expected even though there's a couple of errors in the logs.

#### Application log errors

There's an error related to `org.eclipse.kura.linux.position_2.0.0.202510121328`. Unrelated to the containerization (can be reproduced on native installer too).

<details><summary>See full log</summary>

```
org.osgi.framework.ServiceException: Exception in org.apache.felix.scr.impl.manager.SingleComponentManager.getService()
	at org.eclipse.osgi.internal.serviceregistry.ServiceFactoryUse.factoryGetService(ServiceFactoryUse.java:236)
	at org.eclipse.osgi.internal.serviceregistry.ServiceFactoryUse.getService(ServiceFactoryUse.java:118)
	at org.eclipse.osgi.internal.serviceregistry.ServiceConsumer$2.getService(ServiceConsumer.java:48)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistrationImpl.getService(ServiceRegistrationImpl.java:580)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.getService(ServiceRegistry.java:548)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.getService(BundleContextImpl.java:672)
	at org.apache.felix.scr.impl.manager.SingleRefPair.getServiceObject(SingleRefPair.java:88)
	at org.apache.felix.scr.impl.inject.methods.BindMethod.getServiceObject(BindMethod.java:675)
	at org.apache.felix.scr.impl.manager.DependencyManager.getServiceObject(DependencyManager.java:2625)
	at org.apache.felix.scr.impl.manager.DependencyManager$MultipleDynamicCustomizer.prebind(DependencyManager.java:441)
	at org.apache.felix.scr.impl.manager.DependencyManager.prebind(DependencyManager.java:1843)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.collectDependencies(AbstractComponentManager.java:1060)
	at org.apache.felix.scr.impl.manager.SingleComponentManager.getServiceInternal(SingleComponentManager.java:955)
	at org.apache.felix.scr.impl.manager.SingleComponentManager.getService(SingleComponentManager.java:920)
	at org.eclipse.osgi.internal.serviceregistry.ServiceFactoryUse$1.run(ServiceFactoryUse.java:226)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:319)
	at org.eclipse.osgi.internal.serviceregistry.ServiceFactoryUse.factoryGetService(ServiceFactoryUse.java:223)
	at org.eclipse.osgi.internal.serviceregistry.ServiceFactoryUse.getService(ServiceFactoryUse.java:118)
	at org.eclipse.osgi.internal.serviceregistry.ServiceConsumer$2.getService(ServiceConsumer.java:48)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistrationImpl.getService(ServiceRegistrationImpl.java:580)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.getService(ServiceRegistry.java:548)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.getService(BundleContextImpl.java:672)
	at org.apache.felix.scr.impl.manager.SingleRefPair.getServiceObject(SingleRefPair.java:88)
	at org.apache.felix.scr.impl.inject.methods.BindMethod.getServiceObject(BindMethod.java:675)
	at org.apache.felix.scr.impl.manager.DependencyManager.getServiceObject(DependencyManager.java:2625)
	at org.apache.felix.scr.impl.manager.DependencyManager.doInvokeBindMethod(DependencyManager.java:2091)
	at org.apache.felix.scr.impl.manager.DependencyManager.invokeBindMethod(DependencyManager.java:2074)
	at org.apache.felix.scr.impl.manager.SingleComponentManager.invokeBindMethod(SingleComponentManager.java:443)
	at org.apache.felix.scr.impl.manager.DependencyManager$SingleDynamicCustomizer.tryInvokeBind0(DependencyManager.java:966)
	at org.apache.felix.scr.impl.manager.DependencyManager$SingleDynamicCustomizer.tryInvokeBind(DependencyManager.java:883)
	at org.apache.felix.scr.impl.manager.DependencyManager$SingleDynamicCustomizer.addedService(DependencyManager.java:854)
	at org.apache.felix.scr.impl.manager.DependencyManager$SingleDynamicCustomizer.addedService(DependencyManager.java:816)
	at org.apache.felix.scr.impl.manager.ServiceTracker$Tracked.customizerAdded(ServiceTracker.java:1232)
	at org.apache.felix.scr.impl.manager.ServiceTracker$Tracked.customizerAdded(ServiceTracker.java:1152)
	at org.apache.felix.scr.impl.manager.ServiceTracker$AbstractTracked.trackAdding(ServiceTracker.java:959)
	at org.apache.felix.scr.impl.manager.ServiceTracker$AbstractTracked.track(ServiceTracker.java:895)
	at org.apache.felix.scr.impl.manager.ServiceTracker$Tracked.serviceChanged(ServiceTracker.java:1184)
	at org.apache.felix.scr.impl.BundleComponentActivator$ListenerInfo.serviceChanged(BundleComponentActivator.java:117)
	at org.eclipse.osgi.internal.serviceregistry.FilteredServiceListener.serviceChanged(FilteredServiceListener.java:133)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.dispatchEvent(BundleContextImpl.java:995)
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230)
	at org.eclipse.osgi.framework.eventmgr.ListenerQueue.dispatchEventSynchronous(ListenerQueue.java:151)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.publishServiceEventPrivileged(ServiceRegistry.java:956)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.publishServiceEvent(ServiceRegistry.java:890)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistrationImpl.register(ServiceRegistrationImpl.java:145)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.registerService(ServiceRegistry.java:274)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.registerService(BundleContextImpl.java:501)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager$3.register(AbstractComponentManager.java:929)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager$3.register(AbstractComponentManager.java:915)
	at org.apache.felix.scr.impl.manager.RegistrationManager.changeRegistration(RegistrationManager.java:133)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.registerService(AbstractComponentManager.java:984)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.activateInternal(AbstractComponentManager.java:752)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.enableInternal(AbstractComponentManager.java:674)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.enable(AbstractComponentManager.java:437)
	at org.apache.felix.scr.impl.manager.ConfigurableComponentHolder.configurationUpdated(ConfigurableComponentHolder.java:445)
	at org.apache.felix.scr.impl.manager.RegionConfigurationSupport.configurationEvent(RegionConfigurationSupport.java:347)
	at org.apache.felix.scr.impl.manager.RegionConfigurationSupport$2.configurationEvent(RegionConfigurationSupport.java:115)
	at org.eclipse.equinox.internal.cm.EventDispatcher$1.run(EventDispatcher.java:100)
	at org.eclipse.equinox.internal.cm.SerializedTaskQueue$1.run(SerializedTaskQueue.java:41)
Caused by: java.lang.NoClassDefFoundError: de/taimos/gpsd4java/api/IObjectListener
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1027)
	at org.eclipse.osgi.internal.loader.ModuleClassLoader.defineClass(ModuleClassLoader.java:293)
	at org.eclipse.osgi.internal.loader.classpath.ClasspathManager.defineClass(ClasspathManager.java:774)
	at org.eclipse.osgi.internal.loader.classpath.ClasspathManager.findClassImpl(ClasspathManager.java:691)
	at org.eclipse.osgi.internal.loader.classpath.ClasspathManager.findLocalClassImpl(ClasspathManager.java:657)
	at org.eclipse.osgi.internal.loader.classpath.ClasspathManager.findLocalClassImpl(ClasspathManager.java:637)
	at org.eclipse.osgi.internal.loader.classpath.ClasspathManager.findLocalClass(ClasspathManager.java:616)
	at org.eclipse.osgi.internal.loader.ModuleClassLoader.findLocalClass(ModuleClassLoader.java:348)
	at org.eclipse.osgi.internal.loader.BundleLoader.findLocalClass(BundleLoader.java:414)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass0(BundleLoader.java:520)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:434)
	at org.eclipse.osgi.internal.loader.ModuleClassLoader.loadClass(ModuleClassLoader.java:174)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	at org.eclipse.osgi.internal.framework.EquinoxBundle.loadClass(EquinoxBundle.java:643)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.initDependencyManagers(AbstractComponentManager.java:1027)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.collectDependencies(AbstractComponentManager.java:1057)
	at org.apache.felix.scr.impl.manager.SingleComponentManager.getServiceInternal(SingleComponentManager.java:955)
	at org.apache.felix.scr.impl.manager.SingleComponentManager.getService(SingleComponentManager.java:920)
	at org.eclipse.osgi.internal.serviceregistry.ServiceFactoryUse$1.run(ServiceFactoryUse.java:226)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:319)
	at org.eclipse.osgi.internal.serviceregistry.ServiceFactoryUse.factoryGetService(ServiceFactoryUse.java:223)
	... 58 more
Caused by: java.lang.ClassNotFoundException: de.taimos.gpsd4java.api.IObjectListener cannot be found by org.eclipse.kura.linux.position_2.0.0.202510121328
	at org.eclipse.osgi.internal.loader.BundleLoader.generateException(BundleLoader.java:562)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass0(BundleLoader.java:557)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:434)
	at org.eclipse.osgi.internal.loader.ModuleClassLoader.loadClass(ModuleClassLoader.java:174)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	... 80 more
```

</details>

#### Installation log errors

They're mostly related to systemd not being correctly run in the container (as expected).

<details><summary>See full log</summary>

```
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to system scope bus via local transport: Host is down
Created symlink '/etc/systemd/system/multi-user.target.wants/kura.service' → '/usr/lib/systemd/system/kura.service'.
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to system scope bus via local transport: Host is down
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to system scope bus via local transport: Host is down
Failed to disable unit: Unit systemd-timesyncd.service does not exist
Failed to disable unit: Unit systemd-timesyncd.service does not exist
The unit files have no installation config (WantedBy=, RequiredBy=, UpheldBy=,
Also=, or Alias= settings in the [Install] section, and DefaultInstance= for
template units). This means they are not meant to be enabled or disabled using systemctl.
 
Possible reasons for having these kinds of units are:
• A unit may be statically enabled by being symlinked from another unit's
  .wants/, .requires/, or .upholds/ directory.
• A unit's purpose may be to act as a helper for some other unit which has
  a requirement dependency on it.
• A unit may be started when needed via activation (socket, path, timer,
  D-Bus, udev, scripted systemctl call, ...).
• In case of template units, the unit is meant to be enabled with some
  instance name specified.
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to system scope bus via local transport: Host is down
Synchronizing state of chrony.service with SysV service script with /usr/lib/systemd/systemd-sysv-install.
Executing: /usr/lib/systemd/systemd-sysv-install disable chrony
Removed '/etc/systemd/system/chronyd.service'.
Removed '/etc/systemd/system/multi-user.target.wants/chrony.service'.
passwd: password changed.
passwd: password changed.
Adding user kurad to group dialout

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

grep: /etc/dbus-1/system.d/wpa_supplicant.conf: No such file or directory
Setting up symlink /usr/lib/x86_64-linux-gnu/libudev.so.0 -> /usr/lib/x86_64-linux-gnu/libudev.so.1
[customize_kura_properties.py] 2025-10-13 06:22:15 INFO Found ethernet interfaces: ['eth0']
[customize_kura_properties.py] 2025-10-13 06:22:15 INFO Found wireless interfaces: []
[customize_kura_properties.py] 2025-10-13 06:22:15 INFO /opt/eclipse/kura/framework/kura.properties : starting editing
[customize_kura_properties.py] 2025-10-13 06:22:15 INFO /opt/eclipse/kura/framework/kura.properties : successfully edited
Setting kura RAM to 1964
Updating RAM values for start_kura.sh
Updating RAM values for start_kura_debug.sh
Updating RAM values for start_kura_background.sh
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to system scope bus via local transport: Host is down
Generating 2,048 bit RSA key pair and self-signed certificate (SHA384withRSA) with a validity of 1,000 days
        for: CN=Kura, OU=Kura, O=Eclipse Foundation, L=Ottawa, ST=Ontario, C=CA
```

</details>