### PR TITLE
ci(docker): docker nightly build

### DIFF
--- a/.jenkins/docker-nightly.groovy
+++ b/.jenkins/docker-nightly.groovy
@@ -30,4 +30,3 @@ timeout(time:90, unit:'MINUTES') {
         }
     }
 }
-

--- a/.jenkins/docker-nightly.groovy
+++ b/.jenkins/docker-nightly.groovy
@@ -1,0 +1,31 @@
+@Library('releng-pipeline') _
+
+timeout(time:90, unit:'MINUTES') {
+    podTemplate(yaml: loadOverridableResource(libraryResource: 'org/eclipsefdn/container/agent.yml')) {
+        node(POD_LABEL) {
+            properties([
+                buildDiscarder(logRotator(numToKeepStr: '5')),
+                disableConcurrentBuilds(),
+                pipelineTriggers([
+                    cron('H H * * H')
+                ])
+            ])
+
+            checkout scm
+
+            withEnv(["HOME=${env.WORKSPACE}"]){
+                stage('build') {
+                    container('containertools') {
+                        containerBuild(
+                            credentialsId: 'docker-bot-token',
+                            name: 'docker.io/eclipsekura/kura',
+                            version: 'nightly',
+                            dockerfile: 'docker/Dockerfile.debian'
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/.jenkins/docker-nightly.groovy
+++ b/.jenkins/docker-nightly.groovy
@@ -18,6 +18,7 @@ timeout(time:90, unit:'MINUTES') {
                     dir('docker') {
                         container('containertools') {
                             containerBuild(
+                                annotation: false,
                                 credentialsId: 'docker-bot-token',
                                 name: 'docker.io/eclipsekura/kura',
                                 version: 'nightly',

--- a/.jenkins/docker-nightly.groovy
+++ b/.jenkins/docker-nightly.groovy
@@ -15,13 +15,15 @@ timeout(time:90, unit:'MINUTES') {
 
             withEnv(["HOME=${env.WORKSPACE}"]){
                 stage('build') {
-                    container('containertools') {
-                        containerBuild(
-                            credentialsId: 'docker-bot-token',
-                            name: 'docker.io/eclipsekura/kura',
-                            version: 'nightly',
-                            dockerfile: 'docker/Dockerfile.debian'
-                        )
+                    dir('docker') {
+                        container('containertools') {
+                            containerBuild(
+                                credentialsId: 'docker-bot-token',
+                                name: 'docker.io/eclipsekura/kura',
+                                version: 'nightly',
+                                dockerfile: 'Dockerfile.debian'
+                            )
+                        }
                     }
                 }
             }

--- a/.jenkins/docker-nightly.groovy
+++ b/.jenkins/docker-nightly.groovy
@@ -7,7 +7,7 @@ timeout(time:90, unit:'MINUTES') {
                 buildDiscarder(logRotator(numToKeepStr: '5')),
                 disableConcurrentBuilds(),
                 pipelineTriggers([
-                    cron('H H * * H')
+                    cron('H 0 * * 6') // Run on Saturday night
                 ])
             ])
 


### PR DESCRIPTION
Follow-up on https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3988. This PR introduces the Jenkins pipeline responsible for building and publishing the Docker nightly build of Kura based on the Dockerfile contained in this repository.

References:
- https://gitlab.eclipse.org/eclipsefdn/it/releng/jenkins-pipeline-service/jenkins-pipeline-library
- https://gitlab.eclipse.org/eclipsefdn/it/releng/jenkins-pipeline-service/jenkins-pipeline-library-sample

Tested with: https://ci.eclipse.org/kura/job/kura-base/job/kura-docker/job/nightly-build/12/

**Note**: at the time of this writing the Nexus-based Kura debian repository is down (see https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5706#note_5767607) and thus the Docker build is failing. To test the pipeline I removed all code dependent on the debian repository and thus was able to correctly push the images on the Dockerhub repo.