### PR TITLE
fix(docker): update Nexus repository following migration

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -22,7 +22,7 @@ RUN if [ "$RELEASE_BUILD" -eq 1 ]; then \
         NEXUS_REPO="kura-apt-dev"; \
         NEXUS_DISTR="unstable"; \
     fi && \
-    echo "deb https://repo3.eclipse.org/repository/${NEXUS_REPO}/ ${NEXUS_DISTR} main" | tee /etc/apt/sources.list.d/kura.list
+    echo "deb https://repo.eclipse.org/repository/${NEXUS_REPO}/ ${NEXUS_DISTR} main" | tee /etc/apt/sources.list.d/kura.list
 
 RUN curl -L "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xba7e3df5edc3fc36" | gpg --dearmor | tee /etc/apt/trusted.gpg.d/kura.gpg > /dev/null
 


### PR DESCRIPTION
Update Nexus repository URL following migration (see https://www.eclipse.org/lists/eclipse.org-committers/msg01548.html).

Currently nightly build are failing: https://ci.eclipse.org/kura/job/kura-base/job/kura-docker/job/nightly-build/32/