### PR TITLE
fix(docker): log4j Rfc5424Layout appender

### DIFF
--- a/docker/log4j.xml
+++ b/docker/log4j.xml
@@ -37,7 +37,7 @@
             <DefaultRolloverStrategy max="10"/>
         </RollingFile>
         <RollingFile name="audit" fileName="${log_dir}/${log_name}-audit.log" filePattern="${log_dir}/${log_name}-audit-%i.log.gz">
-            <RFC5424Layout enterpriseNumber="28392" includeMDC="true" mdcId="RequestContext" appName="EclipseKura" mdcPrefix="" newLine="true">
+            <Rfc5424Layout enterpriseNumber="28392" includeMDC="true" mdcId="RequestContext" appName="EclipseKura" mdcPrefix="" includeNL="true">
                 <LoggerFields>
                     <KeyValuePair key="thread" value="%t"/>
                     <KeyValuePair key="priority" value="%p"/>


### PR DESCRIPTION
This PR corrects the attribute name for including new lines in the `Rfc5424Layout` element of the `docker/log4j.xml` file.

- Changed the attribute from `newLine="true"` to `includeNL="true"` in the `Rfc5424Layout` configuration for the audit rolling file appender to match the correct Log4j syntax.