### PR TITLE
fix: Rfc5424Layout tag case in log4j.xml

### DIFF
--- a/docker/log4j.xml
+++ b/docker/log4j.xml
@@ -44,7 +44,7 @@
                     <KeyValuePair key="category" value="%c"/>
                     <KeyValuePair key="exception" value="%ex"/>
                 </LoggerFields>
-            </RFC5424Layout>
+            </Rfc5424Layout>
             <Policies>
                 <SizeBasedTriggeringPolicy size="20 MB"/>
             </Policies>


### PR DESCRIPTION
This pull request includes a minor fix to the log configuration by correcting the case of an XML tag in the `docker/log4j.xml` file.

* Changed `<RFC5424Layout>` to `<Rfc5424Layout>` to use the correct casing for the layout tag in the log4j configuration.